### PR TITLE
Bump `swift-sysctl` to 0.9.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/p-x9/swift-sysctl.git",
       "state" : {
-        "revision" : "644057e1b49380d769b3b4c3f163b47506cc8e24",
-        "version" : "0.8.0"
+        "revision" : "88861fa7f334b7d8c142b8928e5fce2f4ca4116d",
+        "version" : "0.9.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/p-x9/swift-sysctl.git", from: "0.8.0")
+        .package(url: "https://github.com/p-x9/swift-sysctl.git", exact: "0.9.1")
     ],
     targets: [
         .target(

--- a/Sources/CPUInfo/Model/CPUThreadType.swift
+++ b/Sources/CPUInfo/Model/CPUThreadType.swift
@@ -49,9 +49,10 @@ extension CPUThreadType {
     /// CPU thread type of host pc
     static var current: CPUThreadType? {
 #if arch(x86_64)
-        guard let type = try? Sysctl.sysctl(hw.cputhreadtype) else {
+        guard let _type = try? Sysctl.sysctl("hw.cputhreadtype") else {
             return nil
         }
+        let type = _type.withUnsafeBytes { $0.load(as: UInt32.self) }
         return .init(rawValue: CPUThreadType.RawValue(type))
 #else
         CPUThreadType.none

--- a/Sources/CPUInfo/Model/Core.swift
+++ b/Sources/CPUInfo/Model/Core.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftSysctl
 
-public struct Core<CoreNode: CoreNodeProtocol & NodeCollection> {
+public struct Core<CoreNode: CoreNodeProtocol & NodeCollection>: Sendable {
 
     let _node: ChainedNameNode<CoreNode>
 

--- a/Sources/CPUInfo/Protocol/CoreNodeProtocol.swift
+++ b/Sources/CPUInfo/Protocol/CoreNodeProtocol.swift
@@ -9,7 +9,7 @@
 import Foundation
 import SwiftSysctl
 
-public protocol CoreNodeProtocol {
+public protocol CoreNodeProtocol: Sendable {
     var physicalcpu: LeafNameNode<CInt> { get }
     var logicalcpu: LeafNameNode<CInt> { get }
     var l1icachesize: LeafNameNode<CInt> { get }

--- a/Sources/CPUInfo/arm64/CPUInfo+features.swift
+++ b/Sources/CPUInfo/arm64/CPUInfo+features.swift
@@ -16,7 +16,8 @@ extension CPUInfo {
             ("arm64", try? Sysctl.sysctl(hw.optional.arm64)),
 
             /* Legacy Names ARM Optional Feature Sysctls */
-            // https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/kern/kern_mib.c#L1127
+            // https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/kern_mib.c#L1150
+            // https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/kern/kern_mib.c#L1154
             ("neon", try? Sysctl.sysctl(hw.optional.neon)),
             ("neon_hpfp", try? Sysctl.sysctl(hw.optional.neon_hpfp)),
             ("neon_fp16", try? Sysctl.sysctl(hw.optional.neon_fp16)),
@@ -30,29 +31,31 @@ extension CPUInfo {
 //            ("watchpoint", try? Sysctl.sysctl(hw.optional.watchpoint)),
 //            ("breakpoint", try? Sysctl.sysctl(hw.optional.breakpoint)),
 
+            // https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/osfmk/arm/arm_features.inc#L36
             /* Features from: ID_AA64ISAR0_EL1 */
-            ("armv8_crc32", try? Sysctl.sysctl(hw.optional.armv8_crc32)),
+            ("CRC32", (try? Sysctl.sysctl(hw.optional.arm.FEAT_CRC32)) ?? (try? Sysctl.sysctl(hw.optional.armv8_crc32))),
             ("FlagM", try? Sysctl.sysctl(hw.optional.arm.FEAT_FlagM)),
             ("FlagM2", try? Sysctl.sysctl(hw.optional.arm.FEAT_FlagM2)),
-            ("FHM", try? Sysctl.sysctl(hw.optional.arm.FEAT_FHM)),
+            ("FHM", (try? Sysctl.sysctl(hw.optional.arm.FEAT_FHM)) ?? (try? Sysctl.sysctl(hw.optional.armv8_2_fhm))),
             ("DotProd", try? Sysctl.sysctl(hw.optional.arm.FEAT_DotProd)),
-            ("SHA3", try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA3)),
+            ("SHA3", (try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA3)) ?? (try? Sysctl.sysctl(hw.optional.armv8_2_sha3))),
             ("RDM", try? Sysctl.sysctl(hw.optional.arm.FEAT_RDM)),
-            ("LSE", try? Sysctl.sysctl(hw.optional.arm.FEAT_LSE)),
+            ("LSE", (try? Sysctl.sysctl(hw.optional.arm.FEAT_LSE)) ?? (try? Sysctl.sysctl(hw.optional.armv8_1_atomics))),
             ("SHA256", try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA256)),
-            ("SHA512", try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA512)),
+            ("SHA512", (try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA512)) ?? (try? Sysctl.sysctl(hw.optional.armv8_2_sha512))),
             ("SHA1", try? Sysctl.sysctl(hw.optional.arm.FEAT_SHA1)),
             ("AES", try? Sysctl.sysctl(hw.optional.arm.FEAT_AES)),
             ("PMULL", try? Sysctl.sysctl(hw.optional.arm.FEAT_PMULL)),
 
             /* Features from: ID_AA64ISAR1_EL1 */
-            ("armv8_gpi", try? Sysctl.sysctl(hw.optional.armv8_gpi)),
             ("SPECRES", try? Sysctl.sysctl(hw.optional.arm.FEAT_SPECRES)),
+            ("SPECRES2", try? Sysctl.sysctl(hw.optional.arm.FEAT_SPECRES2)),
             ("SB", try? Sysctl.sysctl(hw.optional.arm.FEAT_SB)),
             ("FRINTTS", try? Sysctl.sysctl(hw.optional.arm.FEAT_FRINTTS)),
+            ("PACIMP", (try? Sysctl.sysctl(hw.optional.arm.FEAT_PACIMP)) ?? (try? Sysctl.sysctl(hw.optional.armv8_gpi))),
             ("LRCPC", try? Sysctl.sysctl(hw.optional.arm.FEAT_LRCPC)),
             ("LRCPC2", try? Sysctl.sysctl(hw.optional.arm.FEAT_LRCPC2)),
-            ("FCMA", try? Sysctl.sysctl(hw.optional.arm.FEAT_FCMA)),
+            ("FCMA", (try? Sysctl.sysctl(hw.optional.arm.FEAT_FCMA)) ?? (try? Sysctl.sysctl(hw.optional.armv8_3_compnum))),
             ("JSCVT", try? Sysctl.sysctl(hw.optional.arm.FEAT_JSCVT)),
             ("PAuth", try? Sysctl.sysctl(hw.optional.arm.FEAT_PAuth)),
             ("PAuth2", try? Sysctl.sysctl(hw.optional.arm.FEAT_PAuth2)),
@@ -60,21 +63,31 @@ extension CPUInfo {
             ("DPB", try? Sysctl.sysctl(hw.optional.arm.FEAT_DPB)),
             ("DPB2", try? Sysctl.sysctl(hw.optional.arm.FEAT_DPB2)),
             ("BF16", try? Sysctl.sysctl(hw.optional.arm.FEAT_BF16)),
+            ("EBF16", try? Sysctl.sysctl(hw.optional.arm.FEAT_EBF16)),
             ("I8MM", try? Sysctl.sysctl(hw.optional.arm.FEAT_I8MM)),
+
+            /* Features from: ID_AA64ISAR2_EL1 */
+            ("WFxT", try? Sysctl.sysctl(hw.optional.arm.FEAT_WFxT)),
+            ("RPRES", try? Sysctl.sysctl(hw.optional.arm.FEAT_RPRES)),
+            ("CSSC", try? Sysctl.sysctl(hw.optional.arm.FEAT_CSSC)),
+            ("HBC", try? Sysctl.sysctl(hw.optional.arm.FEAT_HBC)),
 
             /* Features from: ID_AA64MMFR0_EL1 */
             ("ECV", try? Sysctl.sysctl(hw.optional.arm.FEAT_ECV)),
+
+            /* Features from: ID_AA64MMFR1_EL1 */
+            ("AFP", try? Sysctl.sysctl(hw.optional.arm.FEAT_AFP)),
 
             /* Features from: ID_AA64MMFR2_EL1 */
             ("LSE2", try? Sysctl.sysctl(hw.optional.arm.FEAT_LSE2)),
 
             /* Features from: ID_AA64PFR0_EL1 */
-            ("AdvSIMD", try? Sysctl.sysctl(hw.optional.AdvSIMD)),
-            ("AdvSIMD_HPFPCvt", try? Sysctl.sysctl(hw.optional.AdvSIMD_HPFPCvt)),
             ("CSV2", try? Sysctl.sysctl(hw.optional.arm.FEAT_CSV2)),
             ("CSV3", try? Sysctl.sysctl(hw.optional.arm.FEAT_CSV3)),
             ("DIT", try? Sysctl.sysctl(hw.optional.arm.FEAT_DIT)),
-            ("FP16", try? Sysctl.sysctl(hw.optional.arm.FEAT_FP16)),
+            ("AdvSIMD", (try? Sysctl.sysctl(hw.optional.arm.AdvSIMD)) ?? (try? Sysctl.sysctl(hw.optional.AdvSIMD)) ?? (try? Sysctl.sysctl(hw.optional.neon))),
+            ("AdvSIMD_HPFPCvt", (try? Sysctl.sysctl(hw.optional.arm.AdvSIMD_HPFPCvt)) ?? (try? Sysctl.sysctl(hw.optional.AdvSIMD_HPFPCvt)) ?? (try? Sysctl.sysctl(hw.optional.neon_hpfp))),
+            ("FP16", (try? Sysctl.sysctl(hw.optional.arm.FEAT_FP16)) ?? (try? Sysctl.sysctl(hw.optional.neon_fp16))),
 
             /* Features from: ID_AA64PFR1_EL1 */
             ("SSBS", try? Sysctl.sysctl(hw.optional.arm.FEAT_SSBS)),


### PR DESCRIPTION
- [Add Sendable conformance to CoreNodeProtocol and Core](https://github.com/p-x9/swift-cpu-info/commit/afd24c393514008f5ac76bd64c21ccb65b7e7f5a)
- [Update ARM feature detection with additional sysctl fallbacks and links](https://github.com/p-x9/swift-cpu-info/commit/e4ba58255f21620335f0823a1035780fbebd97e6)